### PR TITLE
Change abbreviation characters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/shortwspath/ShortWsLocator.java
+++ b/src/main/java/org/jenkinsci/plugins/shortwspath/ShortWsLocator.java
@@ -74,6 +74,10 @@ public class ShortWsLocator extends WorkspaceLocator {
         if (usabeSpace > BUILD_PATH_LENGTH) return null; // There is plenty of room
 
         String itemName = StringUtils.abbreviate(item.getName(), 0, 16);
+        // Replace the ellipsis with dashes to avoid problems with msbuild
+        // prior to version 4.6.2.  It used its own path normalization (vs. built in .NET)
+        // which doesn't recognize ... as a valid path.
+        itemName = itemName.replace("...", "---");
         final String digest = Util.getDigestOf(item.getFullName()).substring(0, 8);
         FilePath newPath = slave.getWorkspaceRoot().child(itemName + digest);
 


### PR DESCRIPTION
While ... is valid in Windows, .NET does not recognize this as a valid path.  As a result, tools like msbuild will fail.  After abbreviation, change ... to --- to avoid issues

Also fix tests on Windows
Windows has \ as the path separator character, and a significantly shorter MAX_PATH.  Set the cached path length long enough that a test that doesn't want the path to be shortened passes.
Also replace / with \ on Windows (and vice versa for non-Windows platforms) when comparing paths.
