### PR TITLE
Replace forward slash encoding with underscores & update build to latest LTS Jenkins release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,16 @@
       <version>1.2.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>junit</artifactId>
+			<version>1.5</version>
+		</dependency>
+    <dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>matrix-project</artifactId>
+			<version>1.4</version>
+		</dependency>
   </dependencies>
 
   <repositories>
@@ -52,8 +62,8 @@
   </pluginRepositories>
 
   <properties>
-    <jenkins.version>1.554.1</jenkins.version> <!-- folders plugin -->
-    <jenkins-test-harness.version>2.11</jenkins-test-harness.version>
+    <jenkins.version>2.46.3</jenkins.version> <!-- folders plugin -->
+    <jenkins-test-harness.version>2.22</jenkins-test-harness.version>
     <java.level>7</java.level>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/jenkinsci/plugins/shortwspath/ShortWsLocator.java
+++ b/src/main/java/org/jenkinsci/plugins/shortwspath/ShortWsLocator.java
@@ -31,6 +31,7 @@ import hudson.model.TopLevelItem;
 import hudson.model.Node;
 import hudson.model.Slave;
 import hudson.remoting.VirtualChannel;
+import jenkins.SlaveToMasterFileCallable;
 
 import java.io.File;
 import java.io.IOException;
@@ -81,7 +82,11 @@ public class ShortWsLocator extends WorkspaceLocator {
         final String digest = Util.getDigestOf(item.getFullName()).substring(0, 8);
         FilePath workspaceRoot = slave.getWorkspaceRoot();
         if (workspaceRoot == null) return null; // Slave went offline
-        FilePath newPath = workspaceRoot.child(itemName + digest);
+        String fullPath = itemName + digest;
+        fullPath = fullPath.replace("%2F","_");
+        fullPath = fullPath.replace("%2","_");
+        fullPath = fullPath.replace("%","_");
+        FilePath newPath = workspaceRoot.child(fullPath);
 
         return newPath.getRemote().length() < def.getRemote().length()
                 ? newPath
@@ -121,7 +126,7 @@ public class ShortWsLocator extends WorkspaceLocator {
         return platformMax - prefixLength;
     }
 
-    private static final class Sniffer implements FilePath.FileCallable<Integer> {
+    private static final class Sniffer extends SlaveToMasterFileCallable<Integer> {
 
         public Integer invoke(File ws, VirtualChannel channel) throws IOException, InterruptedException {
             // Good enough for now

--- a/src/test/java/org/jenkinsci/plugins/shortwspath/LocatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/shortwspath/LocatorTest.java
@@ -106,6 +106,24 @@ public class LocatorTest {
     }
 
     @Test
+    public void replaceSlashesInFolders() throws Exception {
+        DumbSlave s = j.createOnlineSlave();
+
+        MockFolder f = j.createFolder("this_is_my_folder_alright");
+        FreeStyleProject p = f.createProject(FreeStyleProject.class, "and%2Fa%2Fproject%2Fin%2Fit");
+        p.setAssignedNode(s);
+
+        // Not enough for anything
+        setMaxPathLength(s, 1);
+
+        FreeStyleBuild b = p.scheduleBuild2(0).get();
+        String buildWs = b.getWorkspace().getRemote();
+        String wsDir = s.getRootPath() + DS + "workspace" + DS;
+        assertThat(buildWs, startsWith(wsDir + "and_a_pro"));
+        assertThat(buildWs, buildWs.length(), equalTo(wsDir.length() + 20));
+    }
+
+    @Test
     public void shortenMatrix() throws Exception {
         Node slave = j.createOnlineSlave();
         setMaxPathLength(slave, 1); // Not enough for anything


### PR DESCRIPTION
Updated plugin to use latest LTS version of Jenkins extending SlaveToMasterFileCallable instead of implementing FilePath.FileCallable.

Replace forward slash encoding with underscore to maintain compatability with multibranch plugins that allow foward slashes in names and maintain Windows node workspace compatibility.

Updated tests to include forward slash replacement handling.