### PR TITLE
Replacing escaped forward slash with dash

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/shortwspath/ShortWsLocator.java
+++ b/src/main/java/org/jenkinsci/plugins/shortwspath/ShortWsLocator.java
@@ -77,7 +77,7 @@ public class ShortWsLocator extends WorkspaceLocator {
         // Replace the ellipsis with dashes to avoid problems with msbuild
         // prior to version 4.6.2.  It used its own path normalization (vs. built in .NET)
         // which doesn't recognize ... as a valid path.
-        itemName = itemName.replace("...", "---");
+        itemName = itemName.replace("...", "---").replace("%2F", "-");
         final String digest = Util.getDigestOf(item.getFullName()).substring(0, 8);
         FilePath workspaceRoot = slave.getWorkspaceRoot();
         if (workspaceRoot == null) return null; // Slave went offline


### PR DESCRIPTION
When using git branches, the workspace location might contain a escaped forward slash:
release/1.0 will end up with
C:\Data\workspaces\release%2F1.0

Some maven plugins have issues with this (it escapes twice).
With the following change we can avoid the issue